### PR TITLE
refactor QuestDetails to use strategy pattern for multiple action types

### DIFF
--- a/apps/govquests-api/rails_app/app/blueprints/quest_blueprint.rb
+++ b/apps/govquests-api/rails_app/app/blueprints/quest_blueprint.rb
@@ -1,7 +1,7 @@
 class QuestBlueprint < Blueprinter::Base
   identifier :quest_id
 
-  fields :quest_type, :audience, :status, :rewards
+  fields :quest_type, :audience, :status, :rewards, :display_data
   field :id do |quest|
     quest.quest_id
   end

--- a/apps/govquests-frontend/src/app/layout.tsx
+++ b/apps/govquests-frontend/src/app/layout.tsx
@@ -27,7 +27,9 @@ export default function RootLayout({
 }>) {
   return (
     <html className="bg-background hgtext-foreground h-full" lang="en">
-      <body className="flex flex-col h-full">{children} </body>
+      <body className="flex flex-col h-full">
+        <Layout>{children}</Layout>{" "}
+      </body>
     </html>
   );
 }

--- a/apps/govquests-frontend/src/app/quests/(components)/QuestDetails.tsx
+++ b/apps/govquests-frontend/src/app/quests/(components)/QuestDetails.tsx
@@ -1,33 +1,87 @@
-import Button from "@/components/Button";
-import RewardIndicator from "@/components/RewardIndicator";
-import type { Quest } from "@/types/quest";
+import React from "react";
 import { ExternalLink, MapIcon, RouteIcon } from "lucide-react";
 import Link from "next/link";
-import type React from "react";
+import Button from "@/components/Button";
+import RewardIndicator from "@/components/RewardIndicator";
+import type { Quest, Action } from "@/types/quest";
 
 interface QuestDetailsProps {
-  quest: Pick<Quest, "title" | "intro" | "actions" | "rewards">;
+  quest: Pick<Quest, "display_data" | "actions" | "rewards">;
 }
+
+interface ActionRenderStrategy {
+  render: (action: Action) => React.ReactNode;
+}
+
+const ReadDocumentStrategy: ActionRenderStrategy = {
+  render: (action) => (
+    <span className="flex items-center gap-2">
+      {action.display_data.content}
+      <Link
+        href={(action.action_data as { document_url: string }).document_url}
+      >
+        <ExternalLink />
+      </Link>
+    </span>
+  ),
+};
+
+const GitcoinScoreStrategy: ActionRenderStrategy = {
+  render: (action) => (
+    <span className="flex items-center gap-2">
+      {action.display_data.content}
+      <span className="text-sm text-gray-500">
+        (Min score: {(action.action_data as { min_score: number }).min_score})
+      </span>
+    </span>
+  ),
+};
+
+const ProposalVoteStrategy: ActionRenderStrategy = {
+  render: (action) => (
+    <span className="flex items-center gap-2">
+      {action.display_data.content}
+      <span className="text-sm text-gray-500">
+        (Proposal ID:{" "}
+        {(action.action_data as { proposal_id: string }).proposal_id})
+      </span>
+    </span>
+  ),
+};
+
+const ActionRenderer: React.FC<{ action: Action }> = ({ action }) => {
+  const strategies: Record<string, ActionRenderStrategy> = {
+    read_document: ReadDocumentStrategy,
+    gitcoin_score: GitcoinScoreStrategy,
+    proposal_vote: ProposalVoteStrategy,
+  };
+
+  const strategy = strategies[action.action_type] || {
+    render: () => <span>{action.display_data.content}</span>,
+  };
+
+  return <>{strategy.render(action)}</>;
+};
 
 const QuestDetails: React.FC<QuestDetailsProps> = ({ quest }) => {
   return (
     <main className="flex items-center justify-center h-full">
       <div className="flex flex-col max-w-[85%]">
-        <div className="flex flex-1 items-center  p-5 md:p-8  bg-black/60 text-optimismForeground rounded-lg mb-3">
+        <div className="flex flex-1 items-center p-5 md:p-8 bg-black/60 text-optimismForeground rounded-lg mb-3">
           <MapIcon width={50} height={50} />
-          <h1 className="text-3xl flex-1 ml-5">{quest.title}</h1>
+          <h1 className="text-3xl flex-1 ml-5">{quest.display_data.title}</h1>
           <div className="flex items-center">
             {quest.rewards.map((reward) => (
               <RewardIndicator key={reward.type} reward={reward} />
             ))}
           </div>
         </div>
-        <div className="flex flex-col flex-1 justify-center bg-primary p-5 md:p-8  rounded-lg">
+        <div className="flex flex-col flex-1 justify-center bg-primary p-5 md:p-8 rounded-lg">
           <div className="flex items-center">
             <div className="w-24 h-24 bg-optimism" />
             <div className="ml-7">
               <h2 className="text-2xl font-medium mb-2">About this quest</h2>
-              <p className="text-lg">{quest.intro}</p>
+              <p className="text-lg">{quest.display_data.intro}</p>
             </div>
           </div>
           <div className="flex items-center my-6">
@@ -36,17 +90,12 @@ const QuestDetails: React.FC<QuestDetailsProps> = ({ quest }) => {
           </div>
           <div className="flex flex-col md:flex-row">
             <div className="flex flex-col">
-              {quest.actions.map((step) => (
+              {quest.actions.map((action) => (
                 <div
                   className="flex flex-1 justify-between items-center mt-3"
-                  key={step.id}
+                  key={action.id}
                 >
-                  <span className="flex items-center gap-2">
-                    {step.content}
-                    <Link href="https://www.google.com.br">
-                      <ExternalLink />
-                    </Link>
-                  </span>
+                  <ActionRenderer action={action} />
                 </div>
               ))}
             </div>

--- a/apps/govquests-frontend/src/types/quest.ts
+++ b/apps/govquests-frontend/src/types/quest.ts
@@ -1,20 +1,71 @@
-export interface Action {
+export interface Quest {
+  quest_id: string;
+  actions: Action[];
+  audience: "AllUsers" | "Delegates" | string;
   id: string;
-  content: string;
-  action_type: string;
+  quest_type: "Onboarding" | "Governance" | string;
+  rewards: Reward[];
+  status: "created" | string;
+  display_data: {
+    intro: string;
+    title: string;
+    image_url: string;
+  };
+}
+
+export type Action =
+  | ReadDocumentAction
+  | GitcoinScoreAction
+  | ProposalVoteAction;
+
+interface BaseAction {
+  action_id: string;
+  id: string;
+  display_data: {
+    content: string;
+  };
+}
+
+export interface ReadDocumentAction extends BaseAction {
+  action_type: "read_document";
+  action_data: {
+    document_url: string;
+  };
+}
+
+export interface GitcoinScoreAction extends BaseAction {
+  action_type: "gitcoin_score";
+  action_data: {
+    min_score: number;
+  };
+}
+
+export interface ProposalVoteAction extends BaseAction {
+  action_type: "proposal_vote";
+  action_data: {
+    proposal_id: string;
+  };
 }
 
 export interface Reward {
-  type: string;
+  type: "Points" | string;
   amount: number;
 }
 
-export interface Quest {
-  id: string;
-  image_url: string;
-  title: string;
-  rewards: Reward[];
-  intro: string;
-  actions: Action[];
-  status: string;
+export function isReadDocumentAction(
+  action: Action
+): action is ReadDocumentAction {
+  return action.action_type === "read_document";
+}
+
+export function isGitcoinScoreAction(
+  action: Action
+): action is GitcoinScoreAction {
+  return action.action_type === "gitcoin_score";
+}
+
+export function isProposalVoteAction(
+  action: Action
+): action is ProposalVoteAction {
+  return action.action_type === "proposal_vote";
 }


### PR DESCRIPTION
- this is an example of how I'm thinking we'd approach multiple action types, each with their own requirements. Whenever we need to render actions/quests we'd probably adopt some variation of this pattern to render the components that completing them require (e.g. Gitcoin verification will require 2 steps, reading a document will probably only require one step, etc).
- next on I plan to work on an implementation of what it would look like to do a quest with the gitcoin integration;