### PR TITLE
feat: create gitcoin score action execution strategy

### DIFF
--- a/apps/govquests-api/rails_app/app/graphql/types/action_content_type.rb
+++ b/apps/govquests-api/rails_app/app/graphql/types/action_content_type.rb
@@ -1,0 +1,6 @@
+module Types
+  class ActionContentType < Types::BaseObject
+    field :title, String, null: true
+    field :description, String, null: true
+  end
+end

--- a/apps/govquests-api/rails_app/app/graphql/types/action_display_data_type.rb
+++ b/apps/govquests-api/rails_app/app/graphql/types/action_display_data_type.rb
@@ -1,0 +1,5 @@
+module Types
+  class ActionDisplayDataType < Types::BaseObject
+    field :content, Types::ActionContentType, null: true
+  end
+end

--- a/apps/govquests-api/rails_app/app/graphql/types/action_type.rb
+++ b/apps/govquests-api/rails_app/app/graphql/types/action_type.rb
@@ -3,7 +3,7 @@ module Types
     field :id, ID, null: false, method: :action_id
     field :action_type, String, null: false
     field :action_data, Types::ActionDataType, null: false
-    field :display_data, Types::DisplayDataType, null: false
+    field :display_data, Types::ActionDisplayDataType, null: false
 
     field :action_executions, [Types::ActionExecutionType], null: true
 

--- a/apps/govquests-api/rails_app/app/graphql/types/display_data_type.rb
+++ b/apps/govquests-api/rails_app/app/graphql/types/display_data_type.rb
@@ -2,6 +2,7 @@ module Types
   class DisplayDataType < Types::BaseObject
     field :title, String, null: true
     field :intro, String, null: true
+    field :requirements, String, null: true
     field :content, String, null: true
     field :image_url, String, null: true
   end

--- a/apps/govquests-api/rails_app/db/seeds.rb
+++ b/apps/govquests-api/rails_app/db/seeds.rb
@@ -15,7 +15,12 @@ end
 read_document = [
   {
     action_type: "read_document",
-    display_data: {content: "Code of conduct"},
+    display_data: {
+      content: {
+        title: "Code of conduct",
+        description: ""
+      }
+    },
     action_data: {
       action_type: "read_document",
       document_url: "https://gov.optimism.io/t/code-of-conduct/5751"
@@ -23,7 +28,12 @@ read_document = [
   },
   {
     action_type: "read_document",
-    display_data: {content: "Optimistic Vision"},
+    display_data: {
+      content: {
+        title: "Optimistic Vision",
+        description: ""
+      }
+    },
     action_data: {
       action_type: "read_document",
       document_url: "https://www.optimism.io/vision"
@@ -31,7 +41,12 @@ read_document = [
   },
   {
     action_type: "read_document",
-    display_data: {content: "Working Constitution"},
+    display_data: {
+      content: {
+        title: "Working Constitution",
+        description: ""
+      }
+    },
     action_data: {
       action_type: "read_document",
       document_url: "https://gov.optimism.io/t/working-constitution-of-the-optimism-collective/55"
@@ -39,7 +54,12 @@ read_document = [
   },
   {
     action_type: "read_document",
-    display_data: {content: "Delegate Expectations"},
+    display_data: {
+      content: {
+        title: "Delegate Expectations",
+        description: ""
+      }
+    },
     action_data: {
       action_type: "read_document",
       document_url: "https://community.optimism.io/token-house/delegate-expectations"
@@ -49,7 +69,12 @@ read_document = [
 
 gitcoin_action = {
   action_type: "gitcoin_score",
-  display_data: {content: "Complete Gitcoin Passport verification"},
+  display_data: {
+    content: {
+      title: "Complete Gitcoin Passport verification",
+      description: "Let’s be sure you’re human!"
+    }
+  },
   action_data: {
     action_type: "gitcoin_score",
     min_score: 20
@@ -83,8 +108,9 @@ quests_data = [
   {
     display_data: {
       title: "gitcoin score quest",
-      intro: "Dive deeper into governance processes and decision-making.",
-      image_url: "https://example.com/advanced-governance.jpg"
+      intro: "Connect your Gitcoin Passport and verify your Unique Humanity Score to help strengthen our community. It’s quick and easy, and you’ll be contributing to a more secure ecosystem!",
+      image_url: "https://example.com/advanced-governance.jpg",
+      requirements: 'Your Unique Humanity Score must be 20 or higher to complete this quest. Not there yet? Check some tips on how to increase your score.'
     },
     quest_type: "Governance",
     audience: "Delegates",

--- a/apps/govquests-api/rails_app/schema.graphql
+++ b/apps/govquests-api/rails_app/schema.graphql
@@ -2,13 +2,22 @@ type Action {
   actionData: ActionData!
   actionExecutions: [ActionExecution!]
   actionType: String!
-  displayData: DisplayData!
+  displayData: ActionDisplayData!
   id: ID!
+}
+
+type ActionContent {
+  description: String
+  title: String
 }
 
 type ActionData {
   actionType: String
   documentUrl: String
+}
+
+type ActionDisplayData {
+  content: ActionContent
 }
 
 type ActionExecution {
@@ -89,6 +98,7 @@ type DisplayData {
   content: String
   imageUrl: String
   intro: String
+  requirements: String
   title: String
 }
 
@@ -149,7 +159,6 @@ type GitcoinScoreStartData implements StartDataInterface {
   Type of the action
   """
   actionType: String!
-  address: String!
   message: String!
   nonce: String!
 }

--- a/apps/govquests-frontend/src/domains/action_tracking/hooks/useActionExecution.ts
+++ b/apps/govquests-frontend/src/domains/action_tracking/hooks/useActionExecution.ts
@@ -1,0 +1,62 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  startActionExecution,
+  completeActionExecution,
+} from "../services/actionService";
+import {
+  StartActionExecutionVariables,
+  CompleteActionExecutionVariables,
+  StartActionExecutionResult,
+  CompleteActionExecutionResult,
+} from "../types/actionTypes";
+
+interface UseActionExecutionReturn {
+  startAction: (variables: StartActionExecutionVariables) => Promise<void>;
+  completeAction: (
+    variables: CompleteActionExecutionVariables,
+  ) => Promise<void>;
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+  isSuccess: boolean;
+}
+
+export const useActionExecution = (
+  questId: string,
+): UseActionExecutionReturn => {
+  const queryClient = useQueryClient();
+
+  const startMutation = useMutation<
+    StartActionExecutionResult,
+    Error,
+    StartActionExecutionVariables
+  >({ mutationFn: startActionExecution });
+
+  const completeMutation = useMutation<
+    CompleteActionExecutionResult,
+    Error,
+    CompleteActionExecutionVariables
+  >({
+    mutationFn: completeActionExecution,
+    onSuccess: (data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["quest", questId] });
+    },
+  });
+
+  const startAction = async (variables: StartActionExecutionVariables) => {
+    await startMutation.mutateAsync(variables);
+  };
+
+  const completeAction = async (
+    variables: CompleteActionExecutionVariables,
+  ) => {
+    await completeMutation.mutateAsync(variables);
+  };
+
+  const isLoading = startMutation.isPending || completeMutation.isPending;
+  const isError = startMutation.isError || completeMutation.isError;
+  const error = startMutation.error || completeMutation.error;
+  const isSuccess = startMutation.isSuccess || completeMutation.isSuccess;
+
+  return { startAction, completeAction, isLoading, isError, error, isSuccess };
+};

--- a/apps/govquests-frontend/src/domains/action_tracking/strategies/ReadDocumentStrategy.tsx
+++ b/apps/govquests-frontend/src/domains/action_tracking/strategies/ReadDocumentStrategy.tsx
@@ -2,9 +2,9 @@ import { useSIWE } from "connectkit";
 import React from "react";
 import { useAccount } from "wagmi";
 import ReadActionButton from "../components/ActionButton";
-import type { ActionStrategy } from "./ActionStrategy";
 import { useCompleteActionExecution } from "../hooks/useCompleteActionExecution";
 import { useStartActionExecution } from "../hooks/useStartActionExecution";
+import type { ActionStrategy } from "./ActionStrategy";
 
 export const ReadDocumentStrategy: ActionStrategy = ({
   questId,
@@ -55,10 +55,10 @@ export const ReadDocumentStrategy: ActionStrategy = ({
 
     return "unstarted";
   };
-
   return (
     <div className="flex w-full justify-between border-t-2 pt-3">
-      <span className="font-medium">{action.displayData.content}</span>
+      <span className="font-medium">{action.displayData.content.title}</span>
+
       <ReadActionButton
         loading={startMutation.isPending || completeMutation.isPending}
         disabled={getStatus() === "completed" || !isSignedIn || !isConnected}

--- a/apps/govquests-frontend/src/domains/questing/graphql/questQuery.ts
+++ b/apps/govquests-frontend/src/domains/questing/graphql/questQuery.ts
@@ -25,7 +25,10 @@ export const QuestQuery = graphql(`
         id
         actionType
         displayData {
-          content
+          content {
+            title
+            description
+          }
         }
         actionData {
           documentUrl
@@ -40,7 +43,7 @@ export const QuestQuery = graphql(`
           nonce
           startedAt
           completedAt
-          startData {
+            startData {
             ... on GitcoinScoreStartData {
               message
               nonce

--- a/apps/govquests-frontend/src/domains/questing/graphql/questsQuery.ts
+++ b/apps/govquests-frontend/src/domains/questing/graphql/questsQuery.ts
@@ -20,7 +20,10 @@ export const QuestsQuery = graphql(`
         id
         actionType
         displayData {
-          content
+          content {
+            title
+            description
+          }
         }
         actionData {
           documentUrl


### PR DESCRIPTION
closes [OP-347](https://linear.app/bleu-builders/issue/OP-347/create-gitcoin-score-action-execution-strategy) 

Description: 
- Create action_display_data_type
- Update seeds to receive needed information
- Add new `requirements` field at quests
- Update `content` to be an objective