### PR TITLE
feat: render agora first vote action execution strategy on the

### DIFF
--- a/apps/govquests-api/rails_app/db/seeds.rb
+++ b/apps/govquests-api/rails_app/db/seeds.rb
@@ -176,6 +176,38 @@ module QuestData
       action_type: "verify_delegate_statement"
     }
   }
+  VERIFY_DELEGATE_STATEMENT = {
+    action_type: "verify_delegate_statement",
+    display_data: {
+      title: "Delegate Statement",
+      description: "<ul><li>Connect your wallet at <a href='https://vote.optimism.io/' target='_blank' rel='noopener noreferrer'>Agora</a> - the home of Optimism voters.</li><li>Write and publish your delegate statement — keep in mind that your statement will be reviewed by Delegators who will decide whether to grant you voting power!</li><li><strong>Here's a suggested format for your delegate statement:</strong><ul><li>A brief introduction about your background in crypto and what makes you a valuable candidate.</li><li>Your thoughts on the <a href='https://www.optimism.io/vision' target='_blank' rel='noopener noreferrer'>Optimistic Vision</a>.</li><li>Insights on the first three articles of the <a href='https://gov.optimism.io/t/working-constitution-of-the-optimism-collective/55' target='_blank' rel='noopener noreferrer'>Working Constitution</a></li><li>Your interests, which can be either general or crypto-related.</li><li>Your favorite crypto projects.</li></ul></li><li><strong>Once your delegate statement is published, come back to GovQuests and verify!</strong></li></ul>"
+    },
+    action_data: {
+      action_type: "verify_delegate_statement"
+    }
+  }
+
+  VERIFY_AGORA = {
+    action_type: "verify_agora",
+    display_data: {
+      title: "Connect to Agora",
+      description: "Agora is the home of Optimism voters. You must connect before voting."
+    },
+    action_data: {
+      action_type: "verify_agora"
+    }
+  }
+
+  VERIFY_FIRST_VOTE = {
+    action_type: "verify_first_vote",
+    display_data: {
+      title: "Cast your first vote",
+      description: "<ul><li>Choose an <a href='https://vote.optimism.io/' target='_blank' rel='noopener noreferrer'>open proposal here</a> and <strong>cast your vote.</strong></li><li>Don't forget to <strong>share your reasoning</strong> to help the community understand your perspective.</li><li>Once you're done, <strong>come back to complete the quest and claim your reward.</strong></li></ul>"
+    },
+    action_data: {
+      action_type: "verify_first_vote"
+    }
+  }
 
   QUESTS = [
     {
@@ -260,6 +292,18 @@ module QuestData
       audience: "Delegates",
       rewards: [{type: "Points", amount: 20}],
       actions: [VERIFY_DELEGATE_STATEMENT]
+    },
+    {
+      display_data: {
+        title: "First Vote Milestone",
+        intro: "As a delegate, casting your first vote is an important step in shaping the future. Step up, participate, and make your mark with your first vote!",
+        image_url: "https://example.com/governance101.jpg",
+        requirements: "To complete this quest, you need to <strong>be a registered delegate</strong> — if you’re not, start with Become Delegate Quest — and <strong>not have cast a vote</strong> yet."
+      },
+      quest_type: "Governance",
+      audience: "Delegates",
+      rewards: [{type: "Points", amount: 20}],
+      actions: [VERIFY_AGORA, VERIFY_FIRST_VOTE]
     }
   ]
 end

--- a/apps/govquests-frontend/src/components/ui/HtmlRender.tsx
+++ b/apps/govquests-frontend/src/components/ui/HtmlRender.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@/lib/utils";
+import type React from "react";
+
+interface HtmlRenderProps {
+  content: string;
+}
+
+const HtmlRender: React.FC<HtmlRenderProps> = ({ content }) => {
+  return (
+    <div
+      className={cn(
+        "prose prose-sm max-w-none",
+        "prose-a:underline",
+        "prose-strong:font-bold prose-strong:text-inherit",
+        "prose-ul:list-disc prose-ul:pl-5 prose-ul:mt-0",
+        "prose-li:pl-0 prose-li:my-0",
+      )}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
+      dangerouslySetInnerHTML={{
+        __html: content || "",
+      }}
+    />
+  );
+};
+
+export default HtmlRender;

--- a/apps/govquests-frontend/src/domains/action_tracking/components/ActionButton.tsx
+++ b/apps/govquests-frontend/src/domains/action_tracking/components/ActionButton.tsx
@@ -9,8 +9,10 @@ import type {
   GitcoinScoreStatus,
   ReadDocumentStatus,
   SendEmailStatus,
+  VerifyAgoraStatus,
   VerifyDelegateStatementStatus,
   VerifyDelegateStatus,
+  VerifyFirstVoteStatus,
   VerifyPositionStatus,
   VerifyWalletStatus,
 } from "../types/actionButtonTypes";
@@ -47,6 +49,12 @@ type ActionConfig = {
   };
   verify_delegate_statement: {
     statuses: Record<VerifyDelegateStatementStatus, StatusConfig>;
+  };
+  verify_agora: {
+    statuses: Record<VerifyAgoraStatus, StatusConfig>;
+  };
+  verify_first_vote: {
+    statuses: Record<VerifyFirstVoteStatus, StatusConfig>;
   };
 };
 
@@ -135,6 +143,24 @@ const actionConfig: ActionConfig = {
       completed: {
         label: "Verified",
         icon: <CheckSquareIcon className="ml-2 w-4 h-4" />,
+      },
+    },
+  },
+  verify_agora: {
+    statuses: {
+      unstarted: { label: "Connect Agora", icon: null },
+      completed: {
+        label: "Connected",
+        icon: null,
+      },
+    },
+  },
+  verify_first_vote: {
+    statuses: {
+      unstarted: { label: "Confirm first vote", icon: null },
+      completed: {
+        label: "Vote confirmed",
+        icon: null,
       },
     },
   },

--- a/apps/govquests-frontend/src/domains/action_tracking/strategies/ActionStrategyFactory.ts
+++ b/apps/govquests-frontend/src/domains/action_tracking/strategies/ActionStrategyFactory.ts
@@ -4,8 +4,10 @@ import { EnsStrategy } from "./EnsStrategy";
 import { GitcoinScoreStrategy } from "./GitcoinScoreStrategy";
 import { ReadDocumentStrategy } from "./ReadDocumentStrategy";
 import { SendEmailStrategy } from "./SendEmailStrategy";
+import { VerifyAgora } from "./VerifyAgora";
 import { VerifyDelegateStatement } from "./VerifyDelegateStatement";
 import { VerifyDelegateStrategy } from "./VerifyDelegateStrategy";
+import { VerifyFirstVote } from "./VerifyFirstVote";
 import { VerifyPositionStrategy } from "./VerifyPositionStrategy";
 import { VerifyWalletStrategy } from "./VerifyWalletStrategy";
 
@@ -31,6 +33,10 @@ export class ActionStrategyFactory {
         return VerifyDelegateStrategy;
       case "verify_delegate_statement":
         return VerifyDelegateStatement;
+      case "verify_agora":
+        return VerifyAgora;
+      case "verify_first_vote":
+        return VerifyFirstVote;
       default:
         throw new Error(`Unsupported action type: ${actionType}`);
     }

--- a/apps/govquests-frontend/src/domains/action_tracking/strategies/VerifyAgora.tsx
+++ b/apps/govquests-frontend/src/domains/action_tracking/strategies/VerifyAgora.tsx
@@ -1,0 +1,92 @@
+import { cn } from "@/lib/utils";
+import { useSIWE } from "connectkit";
+import React, { useCallback, useMemo, useState } from "react";
+import { useAccount } from "wagmi";
+import ActionButton from "../components/ActionButton";
+import { useCompleteActionExecution } from "../hooks/useCompleteActionExecution";
+import { useStartActionExecution } from "../hooks/useStartActionExecution";
+import type {
+  ActionType,
+  VerifyWalletStatus,
+} from "../types/actionButtonTypes";
+import type { ActionStrategy } from "./ActionStrategy";
+
+export const VerifyAgora: ActionStrategy = ({
+  questId,
+  action,
+  execution,
+  refetch,
+}) => {
+  const { isSignedIn } = useSIWE();
+  const { isConnected } = useAccount();
+  const startMutation = useStartActionExecution();
+  const completeMutation = useCompleteActionExecution(["quest", questId]);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const handleStart = useCallback(async () => {
+    try {
+      await startMutation.mutateAsync({
+        questId,
+        actionId: action.id,
+        actionType: action.actionType,
+      });
+      refetch();
+      setErrorMessage(null);
+    } catch (error) {
+      console.error("Error starting action:", error);
+      setErrorMessage("Failed to start the verification. Please try again.");
+    }
+  }, [startMutation, questId, action.id, action.actionType, refetch]);
+
+  const getStatus = useCallback((): VerifyWalletStatus => {
+    if (execution?.status === "completed") return "completed";
+    return "unstarted";
+  }, [execution]);
+
+  const buttonProps = useMemo(
+    () => ({
+      actionType: action.actionType as ActionType,
+      status: getStatus(),
+      onClick: handleStart,
+      disabled: getStatus() === "completed" || !isSignedIn || !isConnected,
+      loading: startMutation.isPending || completeMutation.isPending,
+    }),
+    [
+      getStatus,
+      handleStart,
+      isSignedIn,
+      isConnected,
+      startMutation.isPending,
+      completeMutation.isPending,
+      action.actionType,
+    ],
+  );
+
+  return (
+    <div className="flex flex-1 justify-between items-center">
+      <div className="flex flex-col">
+        <span className="text-xl font-semibold mb-1">
+          {action.displayData.title}
+        </span>
+
+        <div
+          className={cn(
+            "prose prose-sm max-w-none",
+            "prose-a:underline",
+            "prose-strong:font-bold prose-strong:text-inherit",
+            "prose-ul:list-disc prose-ul:pl-5 prose-ul:mt-0",
+            "prose-li:pl-0 prose-li:my-0",
+          )}
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
+          dangerouslySetInnerHTML={{
+            __html: action.displayData.description || "",
+          }}
+        />
+        {errorMessage && (
+          <span className="text-sm font-bold">{errorMessage}</span>
+        )}
+      </div>
+      <ActionButton {...buttonProps} />
+    </div>
+  );
+};

--- a/apps/govquests-frontend/src/domains/action_tracking/strategies/VerifyAgora.tsx
+++ b/apps/govquests-frontend/src/domains/action_tracking/strategies/VerifyAgora.tsx
@@ -1,3 +1,4 @@
+import HtmlRender from "@/components/ui/HtmlRender";
 import { cn } from "@/lib/utils";
 import { useSIWE } from "connectkit";
 import React, { useCallback, useMemo, useState } from "react";
@@ -68,20 +69,7 @@ export const VerifyAgora: ActionStrategy = ({
         <span className="text-xl font-semibold mb-1">
           {action.displayData.title}
         </span>
-
-        <div
-          className={cn(
-            "prose prose-sm max-w-none",
-            "prose-a:underline",
-            "prose-strong:font-bold prose-strong:text-inherit",
-            "prose-ul:list-disc prose-ul:pl-5 prose-ul:mt-0",
-            "prose-li:pl-0 prose-li:my-0",
-          )}
-          // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
-          dangerouslySetInnerHTML={{
-            __html: action.displayData.description || "",
-          }}
-        />
+        <HtmlRender content={action.displayData.description || ""} />
         {errorMessage && (
           <span className="text-sm font-bold">{errorMessage}</span>
         )}

--- a/apps/govquests-frontend/src/domains/action_tracking/strategies/VerifyDelegateStatement.tsx
+++ b/apps/govquests-frontend/src/domains/action_tracking/strategies/VerifyDelegateStatement.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils";
+import HtmlRender from "@/components/ui/HtmlRender";
 import { useSIWE } from "connectkit";
 import React, { useCallback, useMemo, useState } from "react";
 import { useAccount } from "wagmi";
@@ -69,19 +69,7 @@ export const VerifyDelegateStatement: ActionStrategy = ({
           {action.displayData.title}
         </span>
 
-        <div
-          className={cn(
-            "prose prose-sm max-w-none",
-            "prose-a:underline",
-            "prose-strong:font-bold prose-strong:text-inherit",
-            "prose-ul:list-disc prose-ul:pl-5 prose-ul:mt-0",
-            "prose-li:pl-0 prose-li:my-0",
-          )}
-          // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
-          dangerouslySetInnerHTML={{
-            __html: action.displayData.description || "",
-          }}
-        />
+        <HtmlRender content={action.displayData.description || ""} />
         {errorMessage && (
           <span className="text-sm font-bold">{errorMessage}</span>
         )}

--- a/apps/govquests-frontend/src/domains/action_tracking/strategies/VerifyDelegateStrategy.tsx
+++ b/apps/govquests-frontend/src/domains/action_tracking/strategies/VerifyDelegateStrategy.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils";
+import HtmlRender from "@/components/ui/HtmlRender";
 import { useSIWE } from "connectkit";
 import React, { useCallback, useMemo, useState } from "react";
 import { useAccount } from "wagmi";
@@ -69,19 +69,7 @@ export const VerifyDelegateStrategy: ActionStrategy = ({
           {action.displayData.title}
         </span>
 
-        <div
-          className={cn(
-            "prose prose-sm max-w-none",
-            "prose-a:underline",
-            "prose-strong:font-bold prose-strong:text-inherit",
-            "prose-ul:list-disc prose-ul:pl-5 prose-ul:mt-0",
-            "prose-li:pl-0 prose-li:my-0",
-          )}
-          // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
-          dangerouslySetInnerHTML={{
-            __html: action.displayData.description || "",
-          }}
-        />
+        <HtmlRender content={action.displayData.description || ""} />
         {errorMessage && (
           <span className="text-sm font-bold">{errorMessage}</span>
         )}

--- a/apps/govquests-frontend/src/domains/action_tracking/strategies/VerifyFirstVote.tsx
+++ b/apps/govquests-frontend/src/domains/action_tracking/strategies/VerifyFirstVote.tsx
@@ -1,0 +1,92 @@
+import { cn } from "@/lib/utils";
+import { useSIWE } from "connectkit";
+import React, { useCallback, useMemo, useState } from "react";
+import { useAccount } from "wagmi";
+import ActionButton from "../components/ActionButton";
+import { useCompleteActionExecution } from "../hooks/useCompleteActionExecution";
+import { useStartActionExecution } from "../hooks/useStartActionExecution";
+import type {
+  ActionType,
+  VerifyWalletStatus,
+} from "../types/actionButtonTypes";
+import type { ActionStrategy } from "./ActionStrategy";
+
+export const VerifyFirstVote: ActionStrategy = ({
+  questId,
+  action,
+  execution,
+  refetch,
+}) => {
+  const { isSignedIn } = useSIWE();
+  const { isConnected } = useAccount();
+  const startMutation = useStartActionExecution();
+  const completeMutation = useCompleteActionExecution(["quest", questId]);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const handleStart = useCallback(async () => {
+    try {
+      await startMutation.mutateAsync({
+        questId,
+        actionId: action.id,
+        actionType: action.actionType,
+      });
+      refetch();
+      setErrorMessage(null);
+    } catch (error) {
+      console.error("Error starting action:", error);
+      setErrorMessage("Failed to start the verification. Please try again.");
+    }
+  }, [startMutation, questId, action.id, action.actionType, refetch]);
+
+  const getStatus = useCallback((): VerifyWalletStatus => {
+    if (execution?.status === "completed") return "completed";
+    return "unstarted";
+  }, [execution]);
+
+  const buttonProps = useMemo(
+    () => ({
+      actionType: action.actionType as ActionType,
+      status: getStatus(),
+      onClick: handleStart,
+      disabled: getStatus() === "completed" || !isSignedIn || !isConnected,
+      loading: startMutation.isPending || completeMutation.isPending,
+    }),
+    [
+      getStatus,
+      handleStart,
+      isSignedIn,
+      isConnected,
+      startMutation.isPending,
+      completeMutation.isPending,
+      action.actionType,
+    ],
+  );
+
+  return (
+    <div className="flex flex-1 justify-between items-center">
+      <div className="flex flex-col">
+        <span className="text-xl font-semibold mb-1">
+          {action.displayData.title}
+        </span>
+
+        <div
+          className={cn(
+            "prose prose-sm max-w-none",
+            "prose-a:underline",
+            "prose-strong:font-bold prose-strong:text-inherit",
+            "prose-ul:list-disc prose-ul:pl-5 prose-ul:mt-0",
+            "prose-li:pl-0 prose-li:my-0",
+          )}
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
+          dangerouslySetInnerHTML={{
+            __html: action.displayData.description || "",
+          }}
+        />
+        {errorMessage && (
+          <span className="text-sm font-bold">{errorMessage}</span>
+        )}
+      </div>
+      <ActionButton {...buttonProps} />
+    </div>
+  );
+};

--- a/apps/govquests-frontend/src/domains/action_tracking/strategies/VerifyFirstVote.tsx
+++ b/apps/govquests-frontend/src/domains/action_tracking/strategies/VerifyFirstVote.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils";
+import HtmlRender from "@/components/ui/HtmlRender";
 import { useSIWE } from "connectkit";
 import React, { useCallback, useMemo, useState } from "react";
 import { useAccount } from "wagmi";
@@ -69,19 +69,7 @@ export const VerifyFirstVote: ActionStrategy = ({
           {action.displayData.title}
         </span>
 
-        <div
-          className={cn(
-            "prose prose-sm max-w-none",
-            "prose-a:underline",
-            "prose-strong:font-bold prose-strong:text-inherit",
-            "prose-ul:list-disc prose-ul:pl-5 prose-ul:mt-0",
-            "prose-li:pl-0 prose-li:my-0",
-          )}
-          // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
-          dangerouslySetInnerHTML={{
-            __html: action.displayData.description || "",
-          }}
-        />
+        <HtmlRender content={action.displayData.description || ""} />
         {errorMessage && (
           <span className="text-sm font-bold">{errorMessage}</span>
         )}

--- a/apps/govquests-frontend/src/domains/action_tracking/types/actionButtonTypes.ts
+++ b/apps/govquests-frontend/src/domains/action_tracking/types/actionButtonTypes.ts
@@ -20,6 +20,10 @@ export type VerifyDelegateStatus = "unstarted" | "completed";
 
 export type VerifyDelegateStatementStatus = "unstarted" | "completed";
 
+export type VerifyAgoraStatus = "unstarted" | "completed";
+
+export type VerifyFirstVoteStatus = "unstarted" | "completed";
+
 export type ActionType =
   | "gitcoin_score"
   | "read_document"

--- a/apps/govquests-frontend/src/domains/questing/components/QuestContentSection.tsx
+++ b/apps/govquests-frontend/src/domains/questing/components/QuestContentSection.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils";
+import HtmlRender from "@/components/ui/HtmlRender";
 import type React from "react";
 interface QuestContentSectionProps {
   title: string;
@@ -15,16 +15,7 @@ const QuestContentSection: React.FC<QuestContentSectionProps> = ({
     <div className={`border-t-2 mt-8 pt-3 ${className}`}>
       <h2 className="text-2xl font-medium mb-2">{title}</h2>
 
-      <div
-        className={cn(
-          "prose prose-sm max-w-none",
-          "prose-a:underline",
-          "prose-strong:font-bold prose-strong:text-inherit",
-          "prose-ul:list-disc prose-ul:pl-5 prose-ul:mt-0",
-          "prose-li:pl-0 prose-li:my-0",
-        )}
-        dangerouslySetInnerHTML={{ __html: content }}
-      />
+      <HtmlRender content={content} />
     </div>
   );
 };


### PR DESCRIPTION
closes [OP-354](https://linear.app/bleu-builders/issue/OP-354/render-agora-first-vote-action-execution-strategy-on-the-frontend)

Description:

- Create first vote milestone quest
- Create verify_agora action UI
- Create  verify_first_vote action UI
- Create HTML renderer component

Screenshot:

![image](https://github.com/user-attachments/assets/d26b24f9-043c-497b-afc1-23e4772df562)
