### PR TITLE
fix: ensure getSession from useSIWE is properly working

### DIFF
--- a/apps/govquests-frontend/src/domains/authentication/components/WalletPopover.tsx
+++ b/apps/govquests-frontend/src/domains/authentication/components/WalletPopover.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/Button";
 import { Popover } from "@/components/ui/popover";
+import Spinner from "@/components/ui/Spinner";
 import { useUserProfile } from "@/hooks/useUserProfile";
 import { cn } from "@/lib/utils";
 import {
@@ -16,11 +17,15 @@ import { useAccount, useBalance, useDisconnect } from "wagmi";
 export const WalletPopover = ({ className }: { className: string }) => {
   const { address } = useAccount();
   const { data: userProfile } = useUserProfile(address);
-  const { disconnect } = useDisconnect();
+  const { disconnect, isPending } = useDisconnect();
 
   const { data: balance } = useBalance({
     address,
   });
+
+  const handleDisconnect = () => {
+    disconnect();
+  };
 
   return (
     <Popover>
@@ -69,7 +74,9 @@ export const WalletPopover = ({ className }: { className: string }) => {
               {Number(balance?.formatted).toFixed(4)} {balance?.symbol}
             </span>
           </div>
-          <Button onClick={() => disconnect()}>Disconnect</Button>
+          <Button onClick={handleDisconnect} disabled={isPending}>
+            {isPending ? <Spinner /> : "Disconnect"}
+          </Button>
         </div>
       </PopoverContent>
     </Popover>

--- a/apps/govquests-frontend/src/domains/authentication/services/authService.ts
+++ b/apps/govquests-frontend/src/domains/authentication/services/authService.ts
@@ -1,4 +1,4 @@
-import request from "graphql-request";
+import { GraphQLClient } from "graphql-request";
 import { GENERATE_SIWE_MESSAGE } from "../graphql/generateSiweMessage";
 import { SIGN_IN_WITH_ETHEREUM } from "../graphql/signInWithEthereum";
 import { SIGN_OUT } from "../graphql/signOut";
@@ -6,24 +6,28 @@ import { CURRENT_USER } from "../graphql/currentUser";
 import { ResultOf, VariablesOf } from "gql.tada";
 import { API_URL } from "@/lib/utils";
 
+const client = new GraphQLClient(API_URL, {
+  credentials: "include",
+});
+
 export const generateSiweMessage = async (
   variables: VariablesOf<typeof GENERATE_SIWE_MESSAGE>,
 ) => {
-  return await request(API_URL, GENERATE_SIWE_MESSAGE, variables);
+  return await client.request(GENERATE_SIWE_MESSAGE, variables);
 };
 
 export const signInWithEthereum = async (
   variables: VariablesOf<typeof SIGN_IN_WITH_ETHEREUM>,
 ) => {
-  return await request(API_URL, SIGN_IN_WITH_ETHEREUM, variables);
+  return await client.request(SIGN_IN_WITH_ETHEREUM, variables);
 };
 
 export const signOut = async () => {
-  return await request(API_URL, SIGN_OUT);
+  return await client.request(SIGN_OUT);
 };
 
 export const fetchCurrentUser = async (): Promise<
   ResultOf<typeof CURRENT_USER>
 > => {
-  return await request(API_URL, CURRENT_USER);
+  return await client.request(CURRENT_USER);
 };

--- a/apps/govquests-frontend/src/wagmi.ts
+++ b/apps/govquests-frontend/src/wagmi.ts
@@ -55,14 +55,20 @@ export const siweConfig: SIWEConfig = {
     return !result?.errors.length;
   },
   getSession: async () => {
-    const { currentUser } = await fetchCurrentUser();
+    try {
+      const { currentUser } = await fetchCurrentUser();
 
-    if (!currentUser) return null;
+      if (!currentUser) {
+        return null;
+      }
 
-    return {
-      address: currentUser.address as `0x${string}`,
-      chainId: currentUser.chainId as number,
-    };
+      return {
+        address: currentUser.address as `0x${string}`,
+        chainId: currentUser.chainId as number,
+      };
+    } catch (error) {
+      return null;
+    }
   },
   signOut: async () => {
     const { signOut: result } = await signOut();


### PR DESCRIPTION
## This PR solves:
When a user disconnect their wallet and try to connect again, the system displays that user is already signed in with ethereum, even when querying to backend was unauthorized. This was preventing user of accessing all actions that need authentication, e.g. user tries to start a quest and receive "Failed to start verification", even if they have the requirements to start and complete that quest.
