### PR TITLE
Juliano/opgov 740 fix quest completion error

### DIFF
--- a/apps/govquests-api/govquests/gamification/lib/gamification/special_badge.rb
+++ b/apps/govquests-api/govquests/gamification/lib/gamification/special_badge.rb
@@ -5,7 +5,9 @@ module Gamification
     class VerificationFailedError < StandardError; end
 
     class AlreadyCreated < StandardError; end
-    
+
+    class RewardPoolAlreadyAssociatedError < StandardError; end
+
     attr_reader :unlocked_by
 
     def initialize(id)
@@ -36,6 +38,8 @@ module Gamification
     end
 
     def associate_reward_pool(pool_id, reward_definition)
+      raise RewardPoolAlreadyAssociatedError if @reward_pools[reward_definition[:type]]
+      
       apply RewardPoolAssociated.new(data: {
         badge_id: @id,
         pool_id:,
@@ -85,10 +89,7 @@ module Gamification
     end
 
     on RewardPoolAssociated do |event|
-      @reward_pools << {
-        pool_id: event.data[:pool_id],
-        reward_definition: event.data[:reward_definition]
-      }
+      @reward_pools[event.data[:reward_definition][:type]] = event.data[:pool_id]
     end
 
     on BadgeUnlocked do |event|

--- a/apps/govquests-api/govquests/gamification/lib/gamification/special_badge.rb
+++ b/apps/govquests-api/govquests/gamification/lib/gamification/special_badge.rb
@@ -15,7 +15,7 @@ module Gamification
       @display_data = nil
       @badge_type = nil
       @badge_data = nil
-      @reward_pools = []
+      @reward_pools = {}
       @unlocked_by = []
     end
 
@@ -39,7 +39,7 @@ module Gamification
 
     def associate_reward_pool(pool_id, reward_definition)
       raise RewardPoolAlreadyAssociatedError if @reward_pools[reward_definition[:type]]
-      
+
       apply RewardPoolAssociated.new(data: {
         badge_id: @id,
         pool_id:,

--- a/apps/govquests-api/govquests/gamification/lib/gamification/special_badge.rb
+++ b/apps/govquests-api/govquests/gamification/lib/gamification/special_badge.rb
@@ -38,7 +38,7 @@ module Gamification
     end
 
     def associate_reward_pool(pool_id, reward_definition)
-      raise RewardPoolAlreadyAssociatedError if @reward_pools[reward_definition[:type]]
+      raise RewardPoolAlreadyAssociatedError if @reward_pools.values.include?(pool_id)
 
       apply RewardPoolAssociated.new(data: {
         badge_id: @id,

--- a/apps/govquests-api/govquests/questing/lib/questing/quest.rb
+++ b/apps/govquests-api/govquests/questing/lib/questing/quest.rb
@@ -37,7 +37,7 @@ module Questing
     end
 
     def associate_reward_pool(pool_id, reward_definition)
-      raise RewardPoolAlreadyAssociatedError if @reward_pools[reward_definition[:type]]
+      raise RewardPoolAlreadyAssociatedError if @reward_pools.values.include?(pool_id)
 
       apply RewardPoolAssociated.new(data: {
         quest_id: @id,

--- a/apps/govquests-api/govquests/questing/lib/questing/quest.rb
+++ b/apps/govquests-api/govquests/questing/lib/questing/quest.rb
@@ -48,7 +48,6 @@ module Questing
 
     def associate_action(action_id, position)
       raise QuestNotCreatedError, "Cannot associate actions before quest creation" unless @state == :created
-      raise ActionAlreadyAssociatedError if @actions.any? { |action| action[:id] == action_id }
 
       apply ActionAssociatedWithQuest.new(data: {
         quest_id: @id,
@@ -78,7 +77,7 @@ module Questing
     end
 
     on ActionAssociatedWithQuest do |event|
-      @actions << {id: event.data[:action_id], position: event.data[:position]}
+      @actions[event.data[:position]] = event.data[:action_id]
     end
 
     on QuestAssociatedWithTrack do |event|

--- a/apps/govquests-api/govquests/questing/lib/questing/quest.rb
+++ b/apps/govquests-api/govquests/questing/lib/questing/quest.rb
@@ -6,6 +6,8 @@ module Questing
 
     AlreadyCreatedError = Class.new(StandardError)
 
+    RewardPoolAlreadyAssociatedError = Class.new(StandardError)
+
     attr_reader :actions, :state, :display_data, :audience
 
     def initialize(id)
@@ -35,6 +37,8 @@ module Questing
     end
 
     def associate_reward_pool(pool_id, reward_definition)
+      raise RewardPoolAlreadyAssociatedError if @reward_pools[reward_definition[:type]]
+
       apply RewardPoolAssociated.new(data: {
         quest_id: @id,
         pool_id: pool_id,
@@ -44,6 +48,7 @@ module Questing
 
     def associate_action(action_id, position)
       raise QuestNotCreatedError, "Cannot associate actions before quest creation" unless @state == :created
+      raise ActionAlreadyAssociatedError if @actions.any? { |action| action[:id] == action_id }
 
       apply ActionAssociatedWithQuest.new(data: {
         quest_id: @id,

--- a/apps/govquests-api/rails_app/app/read_models/gamification/tier_read_model.rb
+++ b/apps/govquests-api/rails_app/app/read_models/gamification/tier_read_model.rb
@@ -20,7 +20,7 @@ module Gamification
     def self.find_by_title(title)
       where("display_data->>'title' = ?", title).first
     end
-    
+
     scope :ordered_by_progression, -> { order(:min_delegation, :max_delegation) }
   end
 end

--- a/apps/govquests-api/rails_app/db/seeds.rb
+++ b/apps/govquests-api/rails_app/db/seeds.rb
@@ -96,6 +96,7 @@ module QuestCreation
         )
       rescue Questing::Quest::RewardPoolAlreadyAssociatedError
         # Silently ignore
+        puts "Reward pool already associated: #{pool_id}"
       end
     end
 
@@ -223,6 +224,7 @@ module SpecialBadgeCreation
         )
       rescue Gamification::SpecialBadge::RewardPoolAlreadyAssociatedError
         # Silently ignore
+        puts "Reward pool already associated: #{pool_id}"
       end
     end
 

--- a/apps/govquests-api/rails_app/db/seeds.rb
+++ b/apps/govquests-api/rails_app/db/seeds.rb
@@ -137,15 +137,17 @@ module TrackCreation
 
     track_data[:quests].each_with_index do |quest_title, index|
       quest_id = quest_id_map[quest_title]
-      Rails.configuration.command_bus.call(
-        Questing::AssociateQuestWithTrack.new(
-          track_id: track_id,
-          quest_id: quest_id,
-          position: index + 1
+      begin
+        Rails.configuration.command_bus.call(
+          Questing::AssociateQuestWithTrack.new(
+            track_id: track_id,
+            quest_id: quest_id,
+            position: index + 1
+          )
         )
-      )
-    rescue Questing::Track::QuestAlreadyAssociated
-      # Silently ignore
+      rescue Questing::Track::QuestAlreadyAssociated
+        # Silently ignore
+      end
     end
 
     track_id

--- a/apps/govquests-api/rails_app/db/seeds.rb
+++ b/apps/govquests-api/rails_app/db/seeds.rb
@@ -86,13 +86,17 @@ module QuestCreation
     quest_data[:rewards].each do |reward|
       pool_id = RewardPoolCreation.create_pool(quest_id, "Questing::QuestReadModel", reward)
 
-      Rails.configuration.command_bus.call(
-        Questing::AssociateRewardPool.new(
-          quest_id: quest_id,
-          pool_id: pool_id,
-          reward_definition: reward
+      begin
+        Rails.configuration.command_bus.call(
+          Questing::AssociateRewardPool.new(
+            quest_id: quest_id,
+            pool_id: pool_id,
+            reward_definition: reward
+          )
         )
-      )
+      rescue Questing::Quest::RewardPoolAlreadyAssociatedError
+        # Silently ignore
+      end
     end
 
     quest_id
@@ -207,13 +211,17 @@ module SpecialBadgeCreation
     badge_data[:rewards].each do |reward|
       pool_id = RewardPoolCreation.create_pool(badge_id, "Gamification::SpecialBadgeReadModel", reward)
 
-      Rails.configuration.command_bus.call(
-        Gamification::AssociateRewardPool.new(
-          badge_id: badge_id,
-          pool_id: pool_id,
-          reward_definition: reward
+      begin
+        Rails.configuration.command_bus.call(
+          Gamification::AssociateRewardPool.new(
+            badge_id: badge_id,
+            pool_id: pool_id,
+            reward_definition: reward
+          )
         )
-      )
+      rescue Gamification::SpecialBadge::RewardPoolAlreadyAssociatedError
+        # Silently ignore
+      end
     end
 
     badge_id


### PR DESCRIPTION
## This PR solves:
```
PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_reward_issuances_on_pool_id_and_user_id"
DETAIL:  Key (pool_id, user_id)=(?) already exists.
```
[Link to error](https://appsignal.com/bleu/sites/67adcfb6599967b41db1574d/exceptions/incidents/14/samples/67adcfb6599967b41db1574d-141883386667068152017404831201)

### What was happening: 
Every time database was reseed, the `reward_pools` on quest aggregate root had one more reward added with the same `pool_id` as before, which causes error while trying to complete quest, making user not able to do that, or even if it can complete, reward was not issued and badge not earned